### PR TITLE
wallet: add pubkey gen for secp256k1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210507181900-4e0be8d2fbb4
 	github.com/drand/kyber v1.1.4
 	github.com/drand/kyber-bls12381 v0.2.1
+	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/lotus v1.8.0
 	github.com/stretchr/testify v1.7.0

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -1,9 +1,12 @@
 package secp256k1
 
 import (
+	"fmt"
+
 	"github.com/dchest/blake2b"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/filecoin-project/go-address"
 )
 
 // Sign creates a secp256k1 signature of a message using a private key.
@@ -23,4 +26,16 @@ func Sign(pk []byte, msg []byte) ([]byte, error) {
 	sig[64] = recoveryID - 27
 
 	return sig, nil
+}
+
+func GetPubKey(pk []byte) (address.Address, error) {
+	priv := secp256k1.PrivKeyFromBytes(pk)
+	pubkey := priv.PubKey()
+
+	addr, err := address.NewSecp256k1Address(pubkey.SerializeUncompressed())
+	if err != nil {
+		return address.Undef, fmt.Errorf("generating public key: %s", err)
+	}
+
+	return addr, nil
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/jsign/go-filsigner/bls"
@@ -43,6 +44,21 @@ func WalletSign(exportedPK string, msg []byte) (*crypto.Signature, error) {
 		}, nil
 	default:
 		return nil, fmt.Errorf("signature type not supported")
+	}
+}
+
+func PublicKey(lotusExportedPK string) (address.Address, error) {
+	ki, err := decodeLotusExportedPK(lotusExportedPK)
+	if err != nil {
+		return address.Undef, fmt.Errorf("decoding lotus exported key: %s", err)
+	}
+
+	switch ki.Type {
+	case types.KTSecp256k1:
+		return secp256k1.GetPubKey(ki.PrivateKey)
+	default:
+		// TODO: support BLS.
+		return address.Undef, fmt.Errorf("signature type not supported")
 	}
 }
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -7,22 +7,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSecp256k1Sign(t *testing.T) {
+func TestSecp256k1(t *testing.T) {
+	t.Parallel()
+
 	// lotus wallet export f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa
 	pk64 := "7b2254797065223a22736563703235366b31222c22507269766174654b6579223a226b35507976337148327349586343595a58594f5775453149326e32554539436861556b6c4e36695a5763453d227d"
-	lotusFormatSig := testSign(t, pk64)
 
-	// lotus wallet sign f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa 44554b45
-	require.Equal(t, "0103bff286f1371c1a4ce8e33c29d6a20eeb53f17970190d12c5a1c0fc4be9a56e766250d5a82dda2179fa90ae297696d1dfaa9eea8f2f833da0cf87b927294eb700", lotusFormatSig)
+	t.Run("sign", func(t *testing.T) {
+		t.Parallel()
+
+		lotusFormatSig := testSign(t, pk64)
+
+		// lotus wallet sign f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa 44554b45
+		require.Equal(t, "0103bff286f1371c1a4ce8e33c29d6a20eeb53f17970190d12c5a1c0fc4be9a56e766250d5a82dda2179fa90ae297696d1dfaa9eea8f2f833da0cf87b927294eb700", lotusFormatSig)
+	})
+
+	t.Run("gen-pubkey", func(t *testing.T) {
+		addr, err := PublicKey(pk64)
+		require.NoError(t, err)
+		require.Equal(t, "f1fib3pv7jua2ockdugtz7viz3cyy6lkhh7rfx3sa", addr.String())
+	})
 }
 
 func TestBLSSign(t *testing.T) {
+	t.Parallel()
+
 	// lotus wallet export f3rpskqryflc2sqzzzu7j2q6fecrkdkv4p2avpf4kyk5u754he7g6cr2rbpmif7pam5oxbme2oyzot4ry3d74q
 	pk64 := "7b2254797065223a22626c73222c22507269766174654b6579223a226862702f794666527439514c43716b6d566171415752436f50556777314b776971716e73684e49704e57513d227d"
-	lotusFormatSig := testSign(t, pk64)
 
-	// lotus wallet sign f3rpskqryflc2sqzzzu7j2q6fecrkdkv4p2avpf4kyk5u754he7g6cr2rbpmif7pam5oxbme2oyzot4ry3d74q 44554b45
-	require.Equal(t, "0280cef41af956cf6855725a5af0d8d956ea41f6da2688cc1f436a7ea5ebd15d96ba384746b819c0836c53a54d6d30b0a70b528204e9da92f833031e7a4776f57bad83e033ea0235bad0f8a5337a4eb66870fc0429175ed63f91203ec1b65c6e31", lotusFormatSig)
+	t.Run("sign", func(t *testing.T) {
+		t.Parallel()
+
+		lotusFormatSig := testSign(t, pk64)
+
+		// lotus wallet sign f3rpskqryflc2sqzzzu7j2q6fecrkdkv4p2avpf4kyk5u754he7g6cr2rbpmif7pam5oxbme2oyzot4ry3d74q 44554b45
+		require.Equal(t, "0280cef41af956cf6855725a5af0d8d956ea41f6da2688cc1f436a7ea5ebd15d96ba384746b819c0836c53a54d6d30b0a70b528204e9da92f833031e7a4776f57bad83e033ea0235bad0f8a5337a4eb66870fc0429175ed63f91203ec1b65c6e31", lotusFormatSig)
+	})
 }
 
 func testSign(t *testing.T, lotusExportedPK string) string {


### PR DESCRIPTION
Adds a new method to `wallet` to generate the public key for secp256k1 from the private key.

The BLS side of the coin is still a TODO.