### PR TITLE
Add negative tests for BLS malleability and zero point vulnerability

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -54,7 +54,7 @@ func WalletVerify(publicKey address.Address, msg []byte, sig []byte) (bool, erro
 	case address.SECP256K1:
 		return secp256k1.Verify(publicKey.Payload(), msg, signature.Data), nil
 	case address.BLS:
-		return bls.Verify(publicKey.Payload(), msg, signature.Data), nil
+		return bls.Verify(publicKey.Payload(), msg, signature.Data)
 	default:
 		return false, fmt.Errorf("address type not supported")
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -196,12 +196,3 @@ func TestBLSSign(t *testing.T) {
 		require.False(t, result)
 	})
 }
-
-type DummyStream struct {
-}
-
-func (d DummyStream) XORKeyStream(dst, src []byte) {
-	for i := range dst {
-		dst[i] = 0
-	}
-}


### PR DESCRIPTION
- [x] Added negative tests for BLS signature malleability - https://github.com/filecoin-project/lotus/security/advisories/GHSA-4g52-pqcj-phvh
- [x] Signing or verifying with zero-point keys should fail - Added negative tests